### PR TITLE
Handle AutoReconnect errors in find_one.

### DIFF
--- a/mongodb_proxy.py
+++ b/mongodb_proxy.py
@@ -23,7 +23,14 @@ log = logging.getLogger(__name__)
 
 MONGO_METHODS_NEEDING_RETRY = {
     pymongo.collection.Collection: [
-        'aggregate', 'ensure_index', 'find', 'group', 'inline_map_reduce', 'map_reduce', 'parallel_scan'
+        'aggregate',
+        'ensure_index',
+        'find',
+        'find_one',
+        'group',
+        'inline_map_reduce',
+        'map_reduce',
+        'parallel_scan',
     ],
 }
 


### PR DESCRIPTION
These aren't currently caught because the `collection.find_one` method
is called, and then it calls `find` without going through the proxy object.