### PR TITLE
(WIP) Fix install issue with MacOSX

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open('README.md') as markdown_source:
 
 try:
     import pandoc
-    pandoc.core.PANDOC_PATH = 'pandoc'
+    # pandoc.core.PANDOC_PATH = 'pandoc'  # Fix install issue with MacOSX
     # Converts the README.md file to ReST, since PyPI uses ReST for formatting,
     # This allows to have one canonical README file, being the README.md
     doc = pandoc.Document()


### PR DESCRIPTION
I haven't tested it back on Linux. But without this change the following wasn't possible:

```
$ pandoc --version
pandoc 1.16.0.2
$ pip --version
pip 7.1.2 from ... site-packages (python 2.7)
$ pip install git+https://github.com/edx/MongoDBProxy.git@25b99097615bda06bd7cdfe5669ed80dc2a7fed0#egg=MongoDBProxy==0.1.0
```


However this is possible:
```
$ pip install git+https://github.com/Edraak/MongoDBProxy.git@2186cfdf588b794936c47b547e8879cd00107cd9#egg=MongoDBProxy==0.1.0
```